### PR TITLE
Fixed control flow between modules

### DIFF
--- a/module.py
+++ b/module.py
@@ -4,8 +4,8 @@ class Module:
 	def __init__(self) -> None:
 		pass
 
-	async def get_res(self, msg: Message) -> str:
-		return ""
+	async def get_res(self, msg: Message) -> str | None:
+		pass
 
-	async def after_res(self, usr_msg: Message, bot_msg: Message | None) -> str:
-		return ""
+	async def after_res(self, usr_msg: Message, bot_msg: Message | None) -> None:
+		pass

--- a/modules/ping.py
+++ b/modules/ping.py
@@ -5,12 +5,11 @@ class PingModule(module.Module):
 	def __init__(self) -> None:
 		super().__init__()
 
-	async def get_res(self, msg: Message) -> str:
+	async def get_res(self, msg: Message) -> str | None:
 		if msg.content != "!ping":
-			return ""
+			return None
 		return "pong!"
 	
-	async def after_res(self, usr_msg: Message, bot_msg: Message | None) -> str:
+	async def after_res(self, usr_msg: Message, bot_msg: Message | None) -> None:
 		await usr_msg.add_reaction("🏓")
 		await bot_msg.add_reaction("🏓")
-		return ""


### PR DESCRIPTION
While fixing the control flow between the Grass modules, I ended up fixing a few other things:
* A psycopg error caused by simply passing a `str` into the `params` parameter of `globs.cursor.execute` instead of a tuple or a list (This error was caused by my previous PR sorry about that)
* Changed the return value of `after_res()` to `None` because after looking at the logic in main.py I saw that there was no need to return a `str`
* Changed the return type annotation of `get_res()` to `str | None` to indicate that it can return either a `str` or a `None`
* Updated the regex expression of the counter module to only take control if the user message strictly contains a number and not any other characters. Otherwise it would steal the control away from the module that I am currently developing.